### PR TITLE
Try to increase productivity with kubectl, using multiple namespaces per context

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,35 +16,11 @@ Effects I seek:
  * Bash completion compatible with per-execution kubectl namespace selection.
  * Display clearly in prompt which context I'm in (aliases in kubectx are great).
 
-Current ~/.bash_profile hack
-
-```bash
-[[ -z "$K_SHELL_ID" ]] && export K_SHELL_ID=$(date +%s%N)
-
-get_kubectx_for_this_shell() {
-  [[ -f ~/.kubectx_history ]] || exit
-  cat ~/.kubectx_history | grep "$K_SHELL_ID=" | tail -n 1 | awk -F '=' '{ print $2 }'
-}
-
-# https://coderwall.com/p/fasnya/add-git-branch-name-to-bash-prompt
-parse_git_branch() {
-  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
-}
-
-host_or_kube_ctx_or_whatever() {
-  AT="";
-
-  [[ "$HOSTNAME" =~ "MacBook" ]] || AT="$HOSTNAME"
-
-  KUBECTX="$(get_kubectx_for_this_shell)"
-
-  [[ -z "$KUBECTX" ]] || AT="$AT$KUBECTX"
-
-  echo "$AT"
-}
-
-export PS1="\u@\[\033[34m\]\$(host_or_kube_ctx_or_whatever)\[\033[00m\] \[\033[32m\]\w\[\033[33m\]\$(parse_git_branch)\[\033[00m\] $ "
-```
+Ah, *forget it*. Switching context in ~/.kube/config
+_introduces a major risk_ because it affects all shells
+on the current host.
+`export KUBECONFIG= ` with separate files for each context
+does not suffer from that risk.
 
 **`kubectx`** help you switch between clusters back and forth:
 ![kubectx demo GIF](img/kubectx-demo.gif)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,36 @@ Effects I seek:
  * Bash completion compatible with per-execution kubectl namespace selection.
  * Display clearly in prompt which context I'm in (aliases in kubectx are great).
 
+Current ~/.bash_profile hack
+
+```bash
+[[ -z "$K_SHELL_ID" ]] && export K_SHELL_ID=$(date +%s%N)
+
+get_kubectx_for_this_shell() {
+  [[ -f ~/.kubectx_history ]] || exit
+  cat ~/.kubectx_history | grep "$K_SHELL_ID=" | tail -n 1 | awk -F '=' '{ print $2 }'
+}
+
+# https://coderwall.com/p/fasnya/add-git-branch-name-to-bash-prompt
+parse_git_branch() {
+  git branch 2> /dev/null | sed -e '/^[^*]/d' -e 's/* \(.*\)/ (\1)/'
+}
+
+host_or_kube_ctx_or_whatever() {
+  AT="";
+
+  [[ "$HOSTNAME" =~ "MacBook" ]] || AT="$HOSTNAME"
+
+  KUBECTX="$(get_kubectx_for_this_shell)"
+
+  [[ -z "$KUBECTX" ]] || AT="$AT$KUBECTX"
+
+  echo "$AT"
+}
+
+export PS1="\u@\[\033[34m\]\$(host_or_kube_ctx_or_whatever)\[\033[00m\] \[\033[32m\]\w\[\033[33m\]\$(parse_git_branch)\[\033[00m\] $ "
+```
+
 **`kubectx`** help you switch between clusters back and forth:
 ![kubectx demo GIF](img/kubectx-demo.gif)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 This repository provides both `kubectx` and `kubens` tools.
 
+** this fork ** is the result of some quick digging of mine into kubectl productivity
+
+I basically got stuck at:
+ - https://github.com/solsson/kube-shell-docker
+ - https://github.com/kubernetes/kubernetes/issues/29322
+ - https://github.com/kubernetes/kubernetes/issues/27308
+ - https://unix.stackexchange.com/questions/4219/how-do-i-get-bash-completion-for-command-aliases
+
+I don't spend a lot of time switching between contexts. Happens per workday, basically.
+But `kubens` from this repo is interesting. However I switch namespace a lot more often
+than I do `cd -` and `git checkout -`.
+
+Effects I seek:
+ * Bash completion compatible with per-execution kubectl namespace selection.
+ * Display clearly in prompt which context I'm in (aliases in kubectx are great).
 
 **`kubectx`** help you switch between clusters back and forth:
 ![kubectx demo GIF](img/kubectx-demo.gif)

--- a/kubectx
+++ b/kubectx
@@ -76,6 +76,9 @@ save_context() {
 
 switch_context() {
   kubectl config use-context "${1}"
+  if [[ -f "${SCRIPT_DIR}/kubeprompt" ]]; then
+    source "${SCRIPT_DIR}/kubeprompt" "${1}"
+  fi
 }
 
 set_context() {

--- a/kubeprompt
+++ b/kubeprompt
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+HISTORY_FILE=~/.kubectx_history
+
+CONTEXT_NAME=${1}
+
+# This is very custom, requires an id exported from ~/.bash_profile etc
+[ -z "$K_SHELL_ID" ] && exit 0
+
+#echo "Shell $K_SHELL_ID context $CONTEXT_NAME ($SCRIPT_DIR)" 
+
+echo "$K_SHELL_ID=$CONTEXT_NAME" >> $HISTORY_FILE


### PR DESCRIPTION
There's quite some activity in this area, but I found nothing with the proper level of respect for what it means that context is per-user, not per shell. You normally have dev, qa and prod clusters.

Not even if the context name is displayed in your shell prompt will you be properly warned from doing something dev-ish in prod: the prompt may be old - you might be hopping between terminal tabs.
